### PR TITLE
Add focus to letter boxes so it will switch to the next box automatic…

### DIFF
--- a/src/components/LetterInputs/LetterInputs.js
+++ b/src/components/LetterInputs/LetterInputs.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { update } from "../../reducers/word";
 import { increment } from "../../reducers/Increment";
@@ -22,6 +22,8 @@ function LetterInputs() {
   const [letterStates, setLetterStates] = useState(
     Array(wordLength).fill({ letter: "", status: false })
   );
+
+  const inputRefs = useRef(Array(wordLength).fill(null))
 
   useEffect(() => {
     // Every time the word changes, update the letter state to a new empty letter objects each with their own status of true = "right" or false = "not right"
@@ -48,8 +50,16 @@ function LetterInputs() {
     // if (changeLetterStatus) {
     //   updatedStates[index] = { letter: value, status: true };
     // }
-    setLetterStates(updatedStates);
+    setLetterStates(updatedStates)
+
+    if (index < wordLength -1 && value !== "") {
+      inputRefs.current[index + 1]?.focus()
+    }
   };
+
+  useEffect(() => {
+    inputRefs.current = Array(wordLength).fill(null)
+  }, [wordLength])
 
   const isLetterCorrect = (wordLetters, index, letterStateToCheck) => {
     if (wordLetters[index] === letterStateToCheck[index].letter) {
@@ -101,6 +111,7 @@ function LetterInputs() {
               maxLength={1}
               key={i}
               value={letterState.letter}
+              ref={element => inputRefs.current[i] = element}
               onChange={(event) => updateLetterState(i, event.target.value)}
               className={
                 submitted ? (letterState.status ? "correct" : "incorrect") : ""


### PR DESCRIPTION


**What I did**:
Added the feature that automatically switches to the next box after key stroke.

**Did this break anything?**

- [x] No
- [ ]  Yes

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix:



**Checklist**

- [ ]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [x]  The code is DRY. If it's not, I tried my best
- [ ]  There are comments where clarification/ organization is needed
- [ ]  There is not broken or commented out code being pushed up
- [x]  I reviewed my code before pushing
- [x]  I ran the app to make sure its working with my changes
- [ ]  I formatted with prettier  ------ forgot this time :( 
- [x]  Does this PR close an issue? If so add it to this pr (#<ticketnumber>)

closes #10  

**What's next?**
Styling the main page (Jen N) and implementing the results page and API 
